### PR TITLE
ncurses: different approach to make ncurses database relocatable

### DIFF
--- a/fwmod
+++ b/fwmod
@@ -1033,7 +1033,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 		if [ "$FREETZ_SHARE_terminfo" == "y" ]; then
 			echo1 "installing terminfos"
 			for i in $(set | grep ^FREETZ_SHARE_terminfo_.*=y |grep -v '^FREETZ_SHARE_terminfo_showall=' ); do
-				dn=usr/share/terminfo
+				dn=${FREETZ_SHARE_libncurses_terminfo_dir#/}
 				conf=${i%%=*}
 				bn=${conf#FREETZ_SHARE_terminfo_}
 				fn=$(echo "$bn" | sed 's/MINUS/-/g;s/PLUS/+/g;s/\DOT/./g')

--- a/make/libs/ncurses/Config.in
+++ b/make/libs/ncurses/Config.in
@@ -40,3 +40,11 @@ config FREETZ_LIB_libpanel
 		the visibility stack or pop to the top at runtime, the resulting book-
 		keeping can be tedious and difficult to get right. Hence the panels
 		library.
+
+config FREETZ_SHARE_NCURSES_DATADIR
+	string "shared data directory location"
+	depends on FREETZ_SHARE_terminfo
+	help
+		Here you may relocate the shared data needed by ncurses libraries, the
+		default location will be '/usr/share' and the sub-directories 'tabset'
+		and 'terminfo' are created there

--- a/make/libs/ncurses/ncurses.mk
+++ b/make/libs/ncurses/ncurses.mk
@@ -10,13 +10,18 @@ $(PKG)_LIBS_BUILD_DIR := $($(PKG)_LIBNAMES_LONG:%=$($(PKG)_DIR)/lib/%)
 $(PKG)_LIBS_STAGING_DIR := $($(PKG)_LIBNAMES_LONG:%=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/%)
 $(PKG)_LIBS_TARGET_DIR := $($(PKG)_LIBNAMES_LONG:%=$($(PKG)_TARGET_DIR)/%)
 
+$(PKG)_DATADIR := $(FREETZ_SHARE_NCURSES_DATADIR)
+ifeq ($(strip $($(PKG)_DATADIR)),"")
+$(PKG)_DATADIR := /usr/share
+endif
+
 $(PKG)_TABSET_MARKER_FILE := std
-$(PKG)_TABSET_DIR := /usr/share/tabset
+$(PKG)_TABSET_DIR := $($(PKG)_DATADIR)/tabset
 $(PKG)_TABSET_STAGING_DIR := $(TARGET_TOOLCHAIN_STAGING_DIR)$($(PKG)_TABSET_DIR)
 $(PKG)_TABSET_TARGET_DIR := $($(PKG)_DEST_DIR)$($(PKG)_TABSET_DIR)
 
 $(PKG)_TERMINFO_MARKER_FILE := .installed
-$(PKG)_TERMINFO_DIR := /usr/share/terminfo
+$(PKG)_TERMINFO_DIR := $($(PKG)_DATADIR)/terminfo
 $(PKG)_TERMINFO_STAGING_DIR := $(TARGET_TOOLCHAIN_STAGING_DIR)$($(PKG)_TERMINFO_DIR)
 $(PKG)_TERMINFO_TARGET_DIR := $($(PKG)_DEST_DIR)$($(PKG)_TERMINFO_DIR)
 
@@ -44,8 +49,9 @@ $(PKG)_CONFIGURE_OPTIONS += --without-manpages
 $(PKG)_CONFIGURE_OPTIONS += --without-tests
 $(PKG)_CONFIGURE_OPTIONS += --with-normal
 $(PKG)_CONFIGURE_OPTIONS += --with-shared
-$(PKG)_CONFIGURE_OPTIONS += --with-terminfo-dirs="$($(PKG)_TERMINFO_DIR)"
-$(PKG)_CONFIGURE_OPTIONS += --with-default-terminfo-dir="$($(PKG)_TERMINFO_DIR)"
+$(PKG)_CONFIGURE_OPTIONS += --datadir=$($(PKG)_DATADIR)
+$(PKG)_CONFIGURE_OPTIONS += --with-terminfo-dirs=$($(PKG)_TERMINFO_DIR)
+$(PKG)_CONFIGURE_OPTIONS += --with-default-terminfo-dir=$($(PKG)_TERMINFO_DIR)
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)
@@ -67,6 +73,7 @@ $($(PKG)_TABSET_STAGING_DIR)/$($(PKG)_TABSET_MARKER_FILE): $($(PKG)_DIR)/.config
 	$(SUBMAKE) -C $(NCURSES_DIR)/misc \
 		DESTDIR="$(TARGET_TOOLCHAIN_STAGING_DIR)" \
 		all install.data
+	mkdir -p $(dir $@); \
 	touch $@
 
 $($(PKG)_TERMINFO_STAGING_DIR)/$($(PKG)_TERMINFO_MARKER_FILE): $($(PKG)_TABSET_STAGING_DIR)/$($(PKG)_TABSET_MARKER_FILE)


### PR DESCRIPTION
- the script 'generate-ncurses-Config.in.sh' is now in the package's make directory, but it will not be used automatically to generate a new 'ncurses-Config.in' file on each build - therefore any changes there are useless and have to be reverted

- now the value for 'datadir' to be used while calling 'configure' for the 'ncurses' library gets adjustable and if no value was specified in the .config file (the default setting), the original value of '/usr/share' will be used

- the 'terminfo' and 'tabset' sub-directories are defined as children of this 'datadir' ... but this are the default names and they could be omitted, as long as it's not intended to rename these directories

- I have let them unchanged to minimize the changes (these additional and redundant settings have survived for more than 10 years now)

ncurses: remove old trace statements

ncurses: remove old trace statements

ncurses.mk: unneeded/unwanted double-quotes